### PR TITLE
Add deep properties censor config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ handler middleware.
   - whitelist `Object`  
     - request `Array.<String>` - request properties to log  
     - response `Array.<String>` - response properties to log  
-  - censor `Array.<String>` - list of request body properties to censor  
+  - censor `Array.<String>` - list of request body properties to censor, this config will deep censor your data. for example, if you input `'data.deepdata'`, your property `deepdata` inside `data` object will be marked as **CENSORED**
 - \[client\] `elasticsearch.Client` - elasticsearch client  
 
 **Returns**: `elasticsearchLoggerMiddleware` - express middleware  

--- a/lib/express-elasticsearch-logger.js
+++ b/lib/express-elasticsearch-logger.js
@@ -7,6 +7,7 @@
 
 var elasticsearch = require('elasticsearch');
 var os = require('os');
+var helper = require('./helper');
 
 /**
  * @module express-elasticsearch-logger
@@ -44,7 +45,7 @@ var os = require('os');
  * @param {Object} config.whitelist
  * @param {Array.<String>} config.whitelist.request request properties to log
  * @param {Array.<String>} config.whitelist.response response properties to log
- * @param {Array.<String>} config.censor list of request body properties to censor
+ * @param {Array.<String>} config.censor list of request body properties to censor, this config will deep censor your data. for example, if you input 'data.deepdata', your property `deepdata` inside `data` object will be marked as **CENSORED**
  * @param {elasticsearch.Client=} client elasticsearch client
  * @returns {elasticsearchLoggerMiddleware} express middleware
  */
@@ -213,11 +214,7 @@ exports.requestHandler = function (config, client) {
     });
 
     if (request.request.body) {
-      config.censor.forEach(function (key) {
-        if (typeof request.request.body[key] !== 'undefined') {
-          request.request.body[key] = '**CENSORED**';
-        }
-      });
+      helper.censor(request.request.body, config.censor)
     }
 
     // monkey patch Response#end to capture request time

--- a/lib/express-elasticsearch-logger.js
+++ b/lib/express-elasticsearch-logger.js
@@ -7,7 +7,7 @@
 
 var elasticsearch = require('elasticsearch');
 var os = require('os');
-var helper = require('./helper');
+var cloneDeep = require('clone-deep');
 
 /**
  * @module express-elasticsearch-logger
@@ -45,7 +45,7 @@ var helper = require('./helper');
  * @param {Object} config.whitelist
  * @param {Array.<String>} config.whitelist.request request properties to log
  * @param {Array.<String>} config.whitelist.response response properties to log
- * @param {Array.<String>} config.censor list of request body properties to censor, this config will deep censor your data. for example, if you input 'data.deepdata', your property `deepdata` inside `data` object will be marked as **CENSORED**
+ * @param {Array.<String>} config.censor list of request body properties to censor
  * @param {elasticsearch.Client=} client elasticsearch client
  * @returns {elasticsearchLoggerMiddleware} express middleware
  */
@@ -207,14 +207,18 @@ exports.requestHandler = function (config, client) {
 
     config.whitelist.request.forEach(function (key) {
       if (typeof req[key] === 'object') {
-        request.request[key] = Object.assign({}, req[key]);
+        request.request[key] = cloneDeep(req[key]);
       } else {
         request.request[key] = req[key];
       }
     });
 
     if (request.request.body) {
-      helper.censor(request.request.body, config.censor)
+      config.censor.forEach(function (key) {
+        if (typeof request.request.body[key] !== 'undefined') {
+          request.request.body[key] = '**CENSORED**';
+        }
+      });
     }
 
     // monkey patch Response#end to capture request time

--- a/lib/express-elasticsearch-logger.js
+++ b/lib/express-elasticsearch-logger.js
@@ -7,6 +7,7 @@
 
 var elasticsearch = require('elasticsearch');
 var os = require('os');
+var helper = require('./helper');
 var cloneDeep = require('clone-deep');
 
 /**
@@ -214,11 +215,7 @@ exports.requestHandler = function (config, client) {
     });
 
     if (request.request.body) {
-      config.censor.forEach(function (key) {
-        if (typeof request.request.body[key] !== 'undefined') {
-          request.request.body[key] = '**CENSORED**';
-        }
-      });
+      helper.censor(request.request.body, config.censor);
     }
 
     // monkey patch Response#end to capture request time

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -10,20 +10,20 @@ exports.censor = function(obj, censorKeyArray) {
         obj[targetKey] = _censorDeep(obj[targetKey], keyArray.splice(1, keyArray.length));
       }
     }
-  })
+  });
 };
 
-const _censorDeep = function(obj, censorKeyArray) {
+var _censorDeep = function(obj, censorKeyArray) {
   if (censorKeyArray.length === 0 && typeof obj !== 'undefined') {
     // this means function reach its base condition, return censor
-    return '**CENSORED**'
+    return '**CENSORED**';
   }
   var targetKey = censorKeyArray[0];
   if (obj instanceof Object && obj[targetKey] !== 'undefined') {
     obj[targetKey] = _censorDeep(obj[targetKey], censorKeyArray.splice(1, censorKeyArray.length));
-    return obj
+    return obj;
   }
-  return obj
+  return obj;
 };
 
 exports._censorDeep = _censorDeep;

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,0 +1,29 @@
+'use strict';
+exports.censor = function(obj, censorKeyArray) {
+  censorKeyArray.forEach(function(key){
+    //split with dot notation
+    var keyArray = key.split('.');
+    if (keyArray.length >= 1) {
+      // this mean the key exist
+      var targetKey = keyArray[0];
+      if (typeof obj[targetKey] !== 'undefined') {
+        obj[targetKey] = _censorDeep(obj[targetKey], keyArray.splice(1, keyArray.length));
+      }
+    }
+  })
+};
+
+const _censorDeep = function(obj, censorKeyArray) {
+  if (censorKeyArray.length === 0 && typeof obj !== 'undefined') {
+    // this means function reach its base condition, return censor
+    return '**CENSORED**'
+  }
+  var targetKey = censorKeyArray[0];
+  if (obj instanceof Object && obj[targetKey] !== 'undefined') {
+    obj[targetKey] = _censorDeep(obj[targetKey], censorKeyArray.splice(1, censorKeyArray.length));
+    return obj
+  }
+  return obj
+};
+
+exports._censorDeep = _censorDeep;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "gulp test"
   },
   "dependencies": {
+    "clone-deep": "^0.2.4",
     "elasticsearch": "^11.0.1"
   },
   "devDependencies": {

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 var expect = require('chai').expect;
-var lib = process.env.JSCOV ? require('../lib-cov/express-elasticsearch-logger') : require('../lib/express-elasticsearch-logger');
-var express = require('express');
 var helper = require('../lib/helper');
 
 var cencorString = '**CENSORED**';
@@ -57,6 +55,6 @@ describe('helper module', function () {
           {z: {zz: {zzz: cencorString}}, b: cencorString, c: {y: cencorString, x: 'remain cool'}}
         );
       });
-    })
+    });
   });
 });

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var expect = require('chai').expect;
+var lib = process.env.JSCOV ? require('../lib-cov/express-elasticsearch-logger') : require('../lib/express-elasticsearch-logger');
+var express = require('express');
+var request = require('supertest');
+
+describe('helper module', function () {
+  describe('methods', function() {
+    context('#test', function() {
+      it('test method', function() {
+        expect(true).to.be.true
+      })
+    })
+  })
+})

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -3,7 +3,6 @@
 var expect = require('chai').expect;
 var lib = process.env.JSCOV ? require('../lib-cov/express-elasticsearch-logger') : require('../lib/express-elasticsearch-logger');
 var express = require('express');
-var request = require('supertest');
 var helper = require('../lib/helper');
 
 var cencorString = '**CENSORED**';

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -4,13 +4,40 @@ var expect = require('chai').expect;
 var lib = process.env.JSCOV ? require('../lib-cov/express-elasticsearch-logger') : require('../lib/express-elasticsearch-logger');
 var express = require('express');
 var request = require('supertest');
+var helper = require('../lib/helper');
+
+var cencorString = '**CENSORED**';
 
 describe('helper module', function () {
   describe('methods', function() {
-    context('#test', function() {
-      it('test method', function() {
-        expect(true).to.be.true
-      })
+    context('#_censorDeep', function() {
+      it('should be able to censor out 1 level config', function() {
+        var original = {
+          a: 'should censor me', b: null, c: 'hello', d: 'haha'
+        };
+        var newObj = helper._censorDeep(original, 'a'.split('.'));
+        expect(newObj).to.deep.equal({a: cencorString, b: null, c: 'hello', d: 'haha'});
+      });
+
+      it('should be able to censor out multi level config', function() {
+        var original = {
+          a: {
+            aa: { aaa: 'keep me out' }
+          }, b: null, c: 'hello', d: 'haha'
+        };
+        var newObj = helper._censorDeep(original, 'a.aa.aaa'.split('.'));
+        expect(newObj).to.have.deep.property('a.aa.aaa', cencorString);
+      });
+
+      it('should remain the same object if the config is at fault', function() {
+        var original = {
+          a: {
+            aa: { aaa: 'keep me out' }
+          }, b: null, c: 'hello', d: 'haha'
+        };
+        var newObj = helper._censorDeep(original, 'a.azd.ewx.1.2'.split('.'));
+        expect(newObj).to.have.deep.equal(original);
+      });
     })
   })
-})
+});

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -38,6 +38,26 @@ describe('helper module', function () {
         var newObj = helper._censorDeep(original, 'a.azd.ewx.1.2'.split('.'));
         expect(newObj).to.have.deep.equal(original);
       });
+    });
+    context('#censor', function() {
+      it('should be able to censor deep config', function() {
+        var original = {z: {zz: {zzz: 'take_me_out'}}};
+        helper.censor(original, ['z.zz.zzz']);
+        expect(original).to.have.deep.property('z.zz.zzz', cencorString);
+      });
+      it('should be able to censor 1 level config', function() {
+        var original = {z: {zz: {zzz: 'take_me_out'}}};
+        helper.censor(original, ['z']);
+        expect(original).to.have.deep.property('z', cencorString);
+      });
+
+      it('should be able to censor multiple configs', function() {
+        var original = {z: {zz: {zzz: 'take_me_out'}}, b: 'this is to be censored too', c: {y: 'out too', x: 'remain cool'}};
+        helper.censor(original, ['z.zz.zzz', 'b', 'c.y']);
+        expect(original).to.deep.equal(
+          {z: {zz: {zzz: cencorString}}, b: cencorString, c: {y: cencorString, x: 'remain cool'}}
+        );
+      });
     })
-  })
+  });
 });


### PR DESCRIPTION
Hi, I really love your lib. It helps me a lot on my on going project. I use it to track down my api error.

Recently, I have been digging deep into your lib on how to use it. I had been using it for a while for capturing http request and response logs but the config I made was wrong so I couldn't capture Error stack trace. After digging in your code, I am able to do that now.

I found the `censor` config was pretty useful to me since I capture all the body of the request. Nonetheless, my project involves with social security number, which is a very sensitive information that I'd like to censor out.

The problem I faced was that the request body sent from the frontend wrap up `ssn` inside an object like so

*request body*
```
{
  form: {
    ssn: 123456789,
    name: 'Lisa'
  }
}
```

I found that I'm unable to config to censor this since I only need to censor the particularly `ssn` field and not the whole `form` object (I need to keep track of requester name).

I think it is a sensible way to be able to config that so I made this pull request so that this config can be done like so;
```
{
  whitelist:{
    request: ['body'],
  },
  censor: [ 'password', 'form.socialSecurityNumber']
}
```

from this setting, if the request sent is like this
```
{
  form: {
    ssn: 123456789,
    name: 'Lisa'
  },
  password: '55555'
}
```

The log that express-elastic-logger will collect would be
```
{
  form: {
    ssn: '**CENSORED**,
    name: 'Lisa'
  },
  password: '**CENSORED**'
}
```

note that the normal case of property within the root of the `body` will be censored and config conventionally like your original API.

I also create a test cases for my function.

I hope you will considor this pull request as a contribution. I have many idea of contributing your lib more in my mind would love to discuss it further.

One last thing is I can't seem to generate the document just like your config using `jsdoc2md` lib. I think some configuration is wrong so I manually add the doc description on the API property setting. I hope you can suggest how to generate the doc 👯‍♂️ 

Regards,
Putt
